### PR TITLE
Error while filtering an editable grid with an uncommitted cell

### DIFF
--- a/src/Behaviors/DataGridFilteringBehavior.cs
+++ b/src/Behaviors/DataGridFilteringBehavior.cs
@@ -182,6 +182,7 @@ namespace NP.Ava.Visuals.DG.Behaviors
             DataGridColumnHeader header = (DataGridColumnHeader)args.Sender;
 
             DataGrid dataGrid = (DataGrid)header.GetPropValue("OwningGrid", true);
+            dataGrid.CommitEdit();
 
             BuildFilter(dataGrid);
         }


### PR DESCRIPTION
Hi Nick,

I've been using your DataGrid filtering functionality for a while and it's been great! I've found an issue in one of my new usecases and have proposed a fix. Please have a look below:

**Replicating the problem**:
1. Have a DataGrid with column filtering and cell editing enabled.
2. Edit a cell, but do not press Enter or commit the change in any way
3. Attempt to filter by typing into the column header textbox.

**Actual behaviour**:
An error is reported in a tooltip attached to a red exclamation mark in the column filter textbox, and filtering does not occur.

**Expected behaviour**:
Filtering should be allowed even while a cell is being actively edited.

**Solution**:
Committing the cell changes prior to building the filter.